### PR TITLE
Add explicit messaging if there are no venue results

### DIFF
--- a/utils/bookingLogic.js
+++ b/utils/bookingLogic.js
@@ -25,6 +25,10 @@ async function checkForExistingBooking() {
 async function fetchDataAndParseSlots() {
   try {
     const response = await axios.request(slotConfig);
+    if (response.data.results.venues.length === 0) {
+      console.log('No slots available. Please run again after reservations open.');
+      return false;
+    }
     console.log(
       `Checking for reservations at ${response.data.results.venues[0].venue.name} on ${convertDateToLongFormat(
         process.env.DATE


### PR DESCRIPTION
Whenever I ran the script after setting up, I would get the following error
```
TypeError: Cannot read properties of undefined (reading 'venue')
    at fetchDataAndParseSlots (file:///Users/jan/Developer/ez-resy/utils/bookingLogic.js:29:71)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/jan/Developer/ez-resy/index.js:15:17

This lead me to believe that my venue ID was somehow wrong but it simply meant there was no possibility to book for the given slot config (which made sense since the reservations were yet to open). I added clear messaging so the user is not confused that the script failed.